### PR TITLE
fix bugs in FFT initialization in increaseNumberOfChannels

### DIFF
--- a/src/properFFTalgorithm.c
+++ b/src/properFFTalgorithm.c
@@ -301,7 +301,7 @@ void increaseNumberOfChannels(struct AllChannelData *allChannelData, int64_t new
     if (allChannelData->maxNumberOfChannelsEver >= newNumberOfChannels) return;
     struct ChannelData **oldChannelDataArray = allChannelData->channelDataArray;
     struct ChannelData **newChannelDataArray = malloc(newNumberOfChannels * sizeof(struct ChannelData*));
-    memcpy(allChannelData->channelDataArray, newChannelDataArray, sizeof(struct ChannelData*) * allChannelData->maxNumberOfChannelsEver);
+    memcpy(newChannelDataArray, allChannelData->channelDataArray, sizeof(struct ChannelData*) * allChannelData->maxNumberOfChannelsEver);
     allChannelData->channelDataArray = newChannelDataArray;
     
     for (int64_t i = allChannelData->maxNumberOfChannelsEver; i < newNumberOfChannels; i++)
@@ -362,7 +362,7 @@ void* threadFunction(void* arg)
     
     // printf("sizeof(pthread_t) = %lld\n", sizeof(pthread_t));
     
-    struct AllChannelData allChannelData;
+    struct AllChannelData allChannelData = {0};
     allChannelData.numberOfChannels = 0;
     allChannelData.maxNumberOfChannelsEver = 0;
     


### PR DESCRIPTION
memcpy had the src and dest parameters swapped and free was called upon an uninitialized pointer, causing a crash:
```
#0  0x00007ffff78ea575 in free () from /usr/lib/libc.so.6
#1  0x000055555555b30a in increaseNumberOfChannels (allChannelData=0x7ffff73ffe50, newNumberOfChannels=2) at .../AcidAnalyzer/src/properFFTalgorithm.c:323
#2  0x000055555555b621 in threadFunction (arg=0x0) at .../AcidAnalyzer/src/properFFTalgorithm.c:427
```